### PR TITLE
retrovert config auto commentout (top level)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     review-retrovert (0.9.4)
-      review (>= 3.2.0)
+      review (>= 3.0.0)
       thor
 
 GEM

--- a/README.md
+++ b/README.md
@@ -22,10 +22,67 @@ Or install it yourself as:
 
     $ gem install review-retrovert
 
-## Usage
+## Commands
+
+```sh
+Commands:
+  review-retrovert convert {review_starter_configfile} {outdir}  # convert Re:VIEW Starter project to Re:VIEW project
+  review-retrovert help [COMMAND]                                # Describe available commands or one specific command
+  review-retrovert version                                       # show version
+```
+
+### Convert
+
+e.g.
 
 ```sh
 review-retrovert convert /path/to/dir/review-starter/config.yml <output directory>
+```
+
+Options
+
+```sh
+Usage:
+  review-retrovert convert {review_starter_configfile} {outdir}
+
+Options:
+  f, [--force]                                     # Force output
+      [--strict], [--no-strict]                    # Only process files registered in the catalog
+      [--preproc], [--no-preproc]                  # Execute preproc after conversion
+      [--tabwidth=N]                               # Preproc tabwidth option value
+                                                   # Default: 0
+      [--table-br-replace=TABLE-BR-REPLACE]        # @<br>{} in table replace string (Default: empty)
+      [--table-empty-replace=TABLE-EMPTY-REPLACE]  # empty cell(.) in table replace string (Default full-width space)
+                                                   # Default: 　
+
+convert Re:VIEW Starter project to Re:VIEW project
+```
+
+#### retrovert config
+
+If the retrovert key is present in config.yml, the subordinate elements will take effect after convert.
+
+If you have a setting that you want to enable only after retrovert, use inherit as shown below.
+
+* config-retrovert.yml
+
+```yml
+retrovert:
+  chapterlink: null
+```
+
+* config-base.yml
+
+```yml
+chapterlink: true
+```
+
+* config.yml
+
+```yml
+inherit: ["config-base.yml", "config-starter.yml", "config-retrovert.yml"]
+
+#chapterlink: true
 ```
 
 ## Development

--- a/lib/review/retrovert/cli.rb
+++ b/lib/review/retrovert/cli.rb
@@ -9,8 +9,8 @@ module ReVIEW
       method_option "strict", desc: 'Only process files registered in the catalog', type: :boolean
       method_option "preproc", desc: 'Execute preproc after conversion', type: :boolean
       method_option "tabwidth", desc: 'Preproc tabwidth option value', type: :numeric, default: 0
-      method_option "table-br-replace", desc: '@<br>{} in table replace string', type: :string, default: ''
-      method_option "table-empty-replace", desc: 'empty cell(.) in table replace string', type: :string, default: '　'
+      method_option "table-br-replace", desc: '@<br>{} in table replace string (Default: empty)', type: :string, default: ''
+      method_option "table-empty-replace", desc: 'empty cell(.) in table replace string (Default full-width space)', type: :string, default: '　'
       def convert(review_starter_configfile, outdir)
         Converter.execute(review_starter_configfile, outdir, options)
       end

--- a/lib/review/retrovert/converter.rb
+++ b/lib/review/retrovert/converter.rb
@@ -67,9 +67,15 @@ module ReVIEW
         @configs.rewrite_yml('contentdir', '.')
         @configs.rewrite_yml('hook_beforetexcompile', 'null')
         @configs.rewrite_yml('texstyle', '["reviewmacro"]')
-        @configs.rewrite_yml('chapterlink', 'null')
+        # @configs.rewrite_yml('chapterlink', 'null')
         pagesize = @config['starter']['pagesize'].downcase
         @configs.rewrite_yml_array('texdocumentclass', "[\"review-jsbook\", \"media=print,paper=#{pagesize}\"]")
+        @config['retrovert'].each{ |k,v|
+          info k
+          unless v..is_a?(Hash)
+            @configs.commentout_root_yml(k)
+          end
+        }
       end
 
       def replace_compatible_block_command_outline(content, command, new_command, option_count)

--- a/lib/review/retrovert/yamlconfig.rb
+++ b/lib/review/retrovert/yamlconfig.rb
@@ -28,7 +28,6 @@ module ReVIEW
 
         @basedir = File.absolute_path(File.dirname(yamlfile))
         @basename = File.basename(yamlfile)
-        @rootyaml = yamlfile
 
         begin
           @config.check_version(ReVIEW::VERSION)
@@ -95,7 +94,7 @@ module ReVIEW
       end
 
       def commentout_root_yml(key)
-        commentout(@rootyaml, key)
+        commentout(File.join(@basedir, @basename), key)
       end
 
       def rewrite_yml_(yamlfile, key, val)

--- a/lib/review/retrovert/yamlconfig.rb
+++ b/lib/review/retrovert/yamlconfig.rb
@@ -28,6 +28,7 @@ module ReVIEW
 
         @basedir = File.absolute_path(File.dirname(yamlfile))
         @basename = File.basename(yamlfile)
+        @rootyaml = yamlfile
 
         begin
           @config.check_version(ReVIEW::VERSION)
@@ -87,9 +88,19 @@ module ReVIEW
         rewrite_retrovert_yml()
       end
 
+      def commentout(yamlfile, key)
+        content = File.read(yamlfile)
+        content.gsub!(/^(\s*)#{key}:(.*)$/, "#\\1#{key}:\\2")
+        File.write(yamlfile, content)
+      end
+
+      def commentout_root_yml(key)
+        commentout(@rootyaml, key)
+      end
+
       def rewrite_yml_(yamlfile, key, val)
         content = File.read(yamlfile)
-        content.gsub!(/^(\s*)#{key}:.*$/, '\1' + "#{key}: #{val}")
+        content.gsub!(/^(\s*)#{key}:.*$/, "\\1#{key}: #{val}")
         File.write(yamlfile, content)
       end
 
@@ -121,6 +132,7 @@ module ReVIEW
           # YAML.dump(yaml, File.open(yamlfile, "w"))
           content = Psych.dump(yaml)
           content.gsub!('---','')
+          content.gsub!(/^(.*):\s*$/, '\1: null')
           File.write(yamlfile, content)
         }
       end

--- a/review-retrovert.gemspec
+++ b/review-retrovert.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "thor"
   spec.add_development_dependency "aruba"
-  spec.add_runtime_dependency "review", ['>= 3.2.0']
+  spec.add_runtime_dependency "review", ['>= 3.0.0']
 end

--- a/spec/review/retrovert_spec.rb
+++ b/spec/review/retrovert_spec.rb
@@ -26,6 +26,8 @@ RSpec.describe 'convert', type: :aruba do
     let(:file92) { 'tmp/92-filelist.re' }
     let(:file93) { 'tmp/93-background.re' }
     let(:file99) { 'tmp/99-postface.re' }
+    let(:config) { 'tmp/config.yml' }
+    let(:retrovert_config) { 'tmp/config-retrovert.yml' }
     before(:each) { run_command("review-retrovert convert --preproc --tabwidth 4 #{config_yaml} tmp") }
 
     it 'command result' do
@@ -237,6 +239,16 @@ RSpec.describe 'convert', type: :aruba do
         text = File.open(File.join(aruba.current_directory, file02)).read()
         expect(text).not_to match(/^:/)
       end
+    end
+
+    it 'retrovert config' do
+      expect(config).to be_an_existing_file
+      text = File.open(File.join(aruba.current_directory, config)).read()
+      expect(text).not_to match(/^chapterlink: .*/)
+
+      expect(retrovert_config).to be_an_existing_file
+      text = File.open(File.join(aruba.current_directory, retrovert_config)).read()
+      expect(text).to match(/^chapterlink: null/)
     end
 
   end

--- a/testdata/mybook/config-retrovert.yml
+++ b/testdata/mybook/config-retrovert.yml
@@ -1,0 +1,7 @@
+# review-retrovert で変換したときに上書きする設定
+# 現在はトップレベルのコメントアウトのみ対応
+# サブ階層の設定を上書きしたい場合は、対象設定を inherit な yml ファイルに記述
+# > inherit: [config-base.yml, config-retrovert.yml]
+# 上記のようにすることで retrovert 後のプロジェクトでのみ設定を上書きできます
+retrovert:
+  chapterlink: null

--- a/testdata/mybook/config.yml
+++ b/testdata/mybook/config.yml
@@ -363,7 +363,7 @@ pdfmaker:
 
 ## @<chapref>{} や @<hd>{} で、章(Chapter)や節(Section)へのリンクを作成
 ## （Re:VIEW の機能だがドキュメントには未記載？）
-#chapterlink: true
+chapterlink: true
 
 
 ## Webページ用の設定

--- a/testdata/mybook/config.yml
+++ b/testdata/mybook/config.yml
@@ -15,7 +15,7 @@ review_version: 2.0
 # その値がB.ymlよりも優先される。
 # 同様にA.yml、B.yml内でさらにinherit:パラメータを使うこともできる。
 # inherit: ["A.yml", "B.yml"]
-inherit: ["config-starter.yml"]
+inherit: ["config-starter.yml", "config-retrovert.yml"]
 
 # ブック名(ファイル名になるもの。ASCII範囲の文字を使用)
 bookname: mybook
@@ -363,7 +363,7 @@ pdfmaker:
 
 ## @<chapref>{} や @<hd>{} で、章(Chapter)や節(Section)へのリンクを作成
 ## （Re:VIEW の機能だがドキュメントには未記載？）
-chapterlink: true
+#chapterlink: true
 
 
 ## Webページ用の設定


### PR DESCRIPTION
retrovert キー配下のトップレベル設定はルートの config.yml の設定をコメントアウトする
ドキュメントとかもろもろ整理