### PR TITLE
Add Dependabot configuration for updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+    groups:
+      actions-minor:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: bundler
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
Configure Dependabot for GitHub Actions and Bundler updates with weekly schedule.